### PR TITLE
allow sending data in request body

### DIFF
--- a/src/SmsSender/HttpAdapter/BuzzHttpAdapter.php
+++ b/src/SmsSender/HttpAdapter/BuzzHttpAdapter.php
@@ -37,9 +37,11 @@ class BuzzHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
     /**
      * {@inheritDoc}
      */
-    public function getContent($url, $method = 'GET', array $headers = array(), array $data = array())
+    public function getContent($url, $method = 'GET', array $headers = array(), $data = array())
     {
-        $data = $this->encodePostData($data);
+        if (is_array($data)) {
+            $data = $this->encodePostData($data);
+        }
 
         try {
             $response = $this->browser->call($url, $method, $headers, $data);
@@ -47,7 +49,7 @@ class BuzzHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
             return null;
         }
 
-        return $response ? $response->getContent() : null;;
+        return $response ? $response->getContent() : null;
     }
 
     /**

--- a/src/SmsSender/HttpAdapter/CurlHttpAdapter.php
+++ b/src/SmsSender/HttpAdapter/CurlHttpAdapter.php
@@ -18,7 +18,7 @@ class CurlHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
     /**
      * {@inheritDoc}
      */
-    public function getContent($url, $method = 'GET', array $headers = array(), array $data = array())
+    public function getContent($url, $method = 'GET', array $headers = array(), $data = array())
     {
         if (!function_exists('curl_init')) {
             throw new \RuntimeException('cURL has to be enabled.');
@@ -34,7 +34,10 @@ class CurlHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
 
         // join the data
         if (!empty($data) && 'POST' === strtoupper($method)) {
-            curl_setopt($c, CURLOPT_POSTFIELDS, $this->encodePostData($data));
+            if (is_array($data)) {
+                $data = $this->encodePostData($data);
+            }
+            curl_setopt($c, CURLOPT_POSTFIELDS, $data);
         }
 
         // and add the headers

--- a/src/SmsSender/HttpAdapter/HttpAdapterInterface.php
+++ b/src/SmsSender/HttpAdapter/HttpAdapterInterface.php
@@ -26,11 +26,14 @@ interface HttpAdapterInterface
      *                              'Content-type: text/plain',
      *                              'Content-length: 100'
      *                         )
-     * @param  array  $data    The data to send when doing non "get" requests.
+     * @param  mixed  $data    The data to send when doing non "get" requests.
+     *                         Gets sent as POST parameters if a key/value
+     *                         array is passed or as request body if a
+     *                         string is passed.
      *
      * @return string
      */
-    public function getContent($url, $method = 'GET', array $headers = array(), array $data = array());
+    public function getContent($url, $method = 'GET', array $headers = array(), $data = array());
 
     /**
      * Returns the name of the HTTP Adapter.


### PR DESCRIPTION
This allows providers to pass string data to `getContent`. If a string is passed it gets sent as request body rather than through request parameters.

This allows integrating APIs that expect a client to send the message payload as a request body.

A provider that implements such an API may be found at [hairmare/SmsSender-Swisscom-Provider](https://github.com/hairmare/SmsSender-Swisscom-Provider). I'll create a pull-request for the provider when the underlying service is considered stable.
