### PR TITLE
SwisscomProvider based on GsmaOneApiProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following providers are supported:
 * [Twilio](https://www.twilio.com/)
 * [CardBoardFish](http://www.cardboardfish.com/)
 * [ValueFirst](http://vfirst.com/) (only covering India's networks)
+* [Swisscom](http://developer.swisscom.com/) (based on the [GSMA OneAPI](http://www.gsma.com/oneapi/) Specification)
 
 Installation
 ------------

--- a/src/SmsSender/Provider/GsmaOneApiProvider.php
+++ b/src/SmsSender/Provider/GsmaOneApiProvider.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This file is part of the SmsSender package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace SmsSender\Provider;
+
+use SmsSender\Exception\InvalidCredentialsException;
+use SmsSender\Exception\InvalidArgumentException;
+use SmsSender\Result\ResultInterface;
+
+/**
+ * @author Lucas Bickel <hairmare@purplehaze.ch>
+ * @see <http://www.gsma.com/oneapi/sms-restful-api/>
+ */
+abstract class GsmaOneApiProvider extends AbstractProvider
+{
+    /**
+     * gsma oneapi url
+     *
+     * the lone %s is set to the senderAddress as per spec.
+     * 
+     * @var string
+     */
+    protected $url = 'http://example.com/v1/smsmessaging/outbound/%s/requests';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param object $adapter              adapter
+     * @param string $international_prefix international prefix
+     *
+     * @return SwisscomProvider
+     */
+    public function __construct($adapter, $international_prefix = '+41')
+    {
+        parent::__construct($adapter);
+
+        $this->international_prefix = $international_prefix;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send($recipient, $body, $originator = '')
+    {
+        if (empty($originator)) {
+            throw new InvalidArgumentException('The originator parameter is required for this provider.');
+        }
+        $url = sprintf(
+            $this->url,
+            urlencode(
+                'tel:'.
+                $this->localNumberToInternational(
+                    $originator,
+                    $this->international_prefix
+                )
+            )
+        );
+        $data = array(
+            'to' => $this->localNumberToInternational($recipient, $this->international_prefix),
+            'text' => $body,
+            'from' => $originator,
+        );
+        return $this->executeQuery($url, $data, array(
+            'recipient' => $recipient,
+            'body' => $body,
+            'originator' => $originator,
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'gsmaoneapi';
+    }
+
+    /**
+     * do the query
+     */
+    protected function executeQuery($url, array $data = array(), array $extra_result_data = array())
+    {
+        $request = new \stdClass;
+        $request->outboundSMSMessageRequest = new \stdClass;
+        $request->outboundSMSMessageRequest->address = array( sprintf('tel:%s', $data['to']) );
+        $request->outboundSMSMessageRequest->senderAddress = sprintf('tel:%s', $data['from']);
+        $request->outboundSMSMessageRequest->outboundSMSTextMessage = new \stdClass;
+        $request->outboundSMSMessageRequest->outboundSMSTextMessage->message = $data['text'];
+                
+        $content = $this->getAdapter()->getContent($url, 'POST', $this->getHeaders(), json_encode($request));
+
+        if (null == $content) {
+            $results = $this->getDefaults();
+        }
+        if (is_string($content)) {
+            $content = json_decode($content, true);
+            $results['id'] = $content['outboundSMSMessageRequest']['clientCorrelator'];
+            switch ($content['outboundSMSMessageRequest']['deliveryInfoList']['deliveryInfo'][0]['deliveryStatus']) {
+                case 'DeliveredToNetwork':
+                    $results['status'] = ResultInterface::STATUS_SENT;
+                    break;
+                case 'DeliveryImpossible':
+                    $results['status'] = ResultInterface::STATUS_FAILED;
+                    break;
+            }
+        }
+
+        return array_merge($results, $extra_result_data);
+    }
+
+    /**
+     * return headers for request
+     *
+     * @return string[]
+     */
+    protected function getHeaders()
+    {
+        return array(
+            'Content-Type: application/json',
+            'Accept: application/json'
+        );
+    }
+}
+
+// vim: set softtabstop=4 tabstop=4 shiftwidth=4 autoindent:

--- a/src/SmsSender/Provider/SwisscomProvider.php
+++ b/src/SmsSender/Provider/SwisscomProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the SmsSender package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace SmsSender\Provider;
+
+use SmsSender\Exception\InvalidCredentialsException;
+use SmsSender\Exception\InvalidArgumentException;
+use SmsSender\Result\ResultInterface;
+
+/**
+ * @author Lucas Bickel <hairmare@purplehaze.ch>
+ * @see <https://developer.swisscom.com/documentation/api/sms-messaging-api>
+ */
+class SwisscomProvider extends GsmaOneApiProvider
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param object $adapter   adapter
+     * @param string $client_id            API-key from developer.swisscom.com
+     * @param string $international_prefix international prefix
+     *
+     * @return SwisscomProvider
+     */
+    public function __construct($adapter, $client_id, $international_prefix = '+41')
+    {
+        parent::__construct($adapter, $international_prefix);
+
+        $this->client_id = $client_id;
+        $this->url = 'https://api.swisscom.com/v1/messaging/sms/outbound/%s/requests';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send($recipient, $body, $originator = '')
+    {
+        if (null == $this->client_id) {
+            throw new InvalidCredentialsException('No API credentials provided');
+        }
+        return parent::send($recipient, $body, $originator);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'swisscom';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getHeaders()
+    {
+        $headers = parent::getHeaders();
+        $headers[] = 'client_id: '.$this->client_id;
+        return $headers;
+    }
+}
+
+// vim: set softtabstop=4 tabstop=4 shiftwidth=4 autoindent:

--- a/tests/SmsSender/Tests/Provider/SwisscomProviderTest.php
+++ b/tests/SmsSender/Tests/Provider/SwisscomProviderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace SmsSender\Tests\Provider;
+
+use SmsSender\Provider\SwisscomProvider;
+use SmsSender\Tests\Provider\BaseProviderTest;
+use SmsSender\Result\ResultInterface;
+
+/**
+ * Tests for SwisscomProvider, based on NexmioProvider tests
+ */
+class SwisscomProviderTest extends BaseProviderTest
+{
+    public function getProvider($adapter)
+    {
+        return new SwisscomProvider($adapter, 'clientId');
+    }
+
+    /**
+     * @expectedException \SmsSender\Exception\InvalidCredentialsException
+     * @expectedExceptionMessage No API credentials provided
+     */
+    public function testSendWithNullApiCredentials()
+    {
+        $adapter = $this->getMock('\SmsSender\HttpAdapter\HttpAdapterInterface');
+        $provider = new SwisscomProvider($adapter, null);
+        $provider->send('0642424242', 'foo!');
+    }
+
+    /**
+     * @expectedException \SmsSender\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The originator parameter is required for this provider.
+     */
+    public function testSendWithNoOriginator()
+    {
+        $adapter = $this->getMock('\SmsSender\HttpAdapter\HttpAdapterInterface');
+        $provider = $this->getProvider($adapter);
+        $provider->send('0642424242', 'foo!');
+    }
+
+    public function testSend()
+    {
+        $provider = $this->getProvider($this->getMockAdapter());
+        $result = $provider->send('0642424242', 'foo', 'originator');
+
+        $this->assertNull($result['id']);
+        $this->assertEquals(ResultInterface::STATUS_FAILED, $result['status']);
+        $this->assertEquals('0642424242', $result['recipient']);
+        $this->assertEquals('foo', $result['body']);
+        $this->assertEquals('originator', $result['originator']);
+    }
+
+    public function testSendWithMockData()
+    {
+        $data = <<<EOF
+{ 
+"outboundSMSMessageRequest": {
+    "address": [
+      "tel:+41originator"
+    ],
+    "deliveryInfoList": {
+      "deliveryInfo": [
+        {
+          "address": "tel:+41642424242",
+          "deliveryStatus": "DeliveredToNetwork"
+        }
+      ],
+      "resourceURL": ""
+    },
+    "senderAddress": "tel:+41originator",
+    "outboundSMSTextMessage": {
+      "message": "foo"
+    },
+    "clientCorrelator": "0A130A1B",
+    "senderName": "originator",
+    "resourceURL": ""
+  }
+}
+EOF;
+        $provider = $this->getProvider($this->getMockAdapter(null, $data));
+        $result = $provider->send('0642424242', 'foo', 'originator');
+
+        $this->assertEquals('0A130A1B', $result['id']);
+        $this->assertEquals(ResultInterface::STATUS_SENT, $result['status']);
+        $this->assertEquals('0642424242', $result['recipient']);
+        $this->assertEquals('foo', $result['body']);
+        $this->assertEquals('originator', $result['originator']);
+    }
+
+    /**
+     * @dataProvider validRecipientProvider
+     */
+    public function testSendCleansRecipientNumber($recipient, $expectedRecipient, $internationalPrefix = null)
+    {
+        // setup the adapter
+        $adapter = $this->getMock('\SmsSender\HttpAdapter\HttpAdapterInterface');
+        $adapter
+            ->expects($this->once())
+            ->method('getContent')
+            ->with(
+                $this->anything(), // URL
+                $this->equalTo('POST'), // method
+                $this->anything(), // headers
+                $this->callback(function ($data) use ($expectedRecipient) {
+                    $data = json_decode($data, true);
+                    $to = array_pop(explode(':', $data['outboundSMSMessageRequest']['address'][0]));
+                    return $to === $expectedRecipient;
+                })
+            );
+
+        // setup the provider
+        if ($internationalPrefix === null) {
+            $provider = new SwisscomProvider($adapter, 'key');
+        } else {
+            $provider = new SwisscomProvider($adapter, 'key', $internationalPrefix);
+        }
+
+        // launch the test
+        $provider->send($recipient, 'foo', 'originator');
+    }
+
+    public function validRecipientProvider()
+    {
+        return array(
+            array('0642424242', '+41642424242', null),
+            array('0642424242', '+33642424242', '+33'),
+            array('0642424242', '+44642424242', '+44'),
+            array('+33642424242', '+33642424242', '+33'),
+            array('+33642424242', '+33642424242', '+44'),
+        );
+    }
+}
+
+// vim: set softtabstop=4 tabstop=4 shiftwidth=4 autoindent:


### PR DESCRIPTION
Hi Kévin

I did some refactoring...

The abstract `GsmaOneApiProvider` contains the parts of the implementation that are described in the gsma specs.  As far as I can tell this part of the code should work with all "gsma oneapi" providers. The `SwisscomProvider` configures the right URL and also implements the Swisscom API-Key.

As far as I can tell the unspecified parts of the standards (like auth) are handled different by the various providers.

Even though I'm not 100% sure as to how production ready the Swisscom service is, I believe that this pull request already contains enough substance to be warranted.

Even though this was not done on work time, I should probably disclaim, that I am currently employed by Swisscom.
