### PR TITLE
2.add error handling in http adapter

### DIFF
--- a/src/Exception/AdapterException.php
+++ b/src/Exception/AdapterException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SmsSender\Exception;
+
+class AdapterException extends RuntimeException
+{
+    /**
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array $data
+     */
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+}

--- a/src/HttpAdapter/BuzzHttpAdapter.php
+++ b/src/HttpAdapter/BuzzHttpAdapter.php
@@ -11,6 +11,7 @@
 namespace SmsSender\HttpAdapter;
 
 use Buzz\Browser;
+use SmsSender\Exception\AdapterException;
 
 /**
  * @author Kévin Gomez <contact@kevingomez.fr>
@@ -44,12 +45,15 @@ class BuzzHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
         }
 
         try {
-            $response = $this->browser->call($url, $method, $headers, $data);
+            if($response = $this->browser->call($url, $method, $headers, $data)){
+                return $response->getContent();
+            }
         } catch (\Exception $e) {
-            return null;
+            if(!empty($e->getMessage())){
+                throw new AdapterException($e->getMessage(), $e->getCode(), $e);
+            }
         }
-
-        return $response ? $response->getContent() : null;
+        throw new AdapterException((string)$this->browser->getLastResponse(), ($this->browser->getLastResponse()) ? $this->browser->getLastResponse()->getStatusCode() : 0);
     }
 
     /**

--- a/src/HttpAdapter/BuzzHttpAdapter.php
+++ b/src/HttpAdapter/BuzzHttpAdapter.php
@@ -59,6 +59,18 @@ class BuzzHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
     {
         return 'buzz';
     }
+
+    /**
+     * Return last request as string or object
+     *
+     * @param bool|false $string
+     *
+     * @return mixed|string
+     */
+    public function getLastRequest($string = false)
+    {
+        return ($string) ? (string)$this->browser->getLastRequest() : $string;
+    }
 }
 
 // vim: set softtabstop=4 tabstop=4 shiftwidth=4 autoindent:

--- a/src/HttpAdapter/CurlHttpAdapter.php
+++ b/src/HttpAdapter/CurlHttpAdapter.php
@@ -10,6 +10,8 @@
 
 namespace SmsSender\HttpAdapter;
 
+use SmsSender\Exception\AdapterException;
+
 /**
  * @author Kévin Gomez <contact@kevingomez.fr>
  */
@@ -60,6 +62,12 @@ class CurlHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
             'data' => $data,
         ]);
 
+        if(curl_errno($c)){
+            $adapterException = new AdapterException(curl_error($c), curl_errno($c));
+            $adapterException->setData(curl_getinfo($c));
+            curl_close($c);
+            throw $adapterException;
+        }
         curl_close($c);
 
         if (false === $content) {

--- a/src/HttpAdapter/CurlHttpAdapter.php
+++ b/src/HttpAdapter/CurlHttpAdapter.php
@@ -16,6 +16,11 @@ namespace SmsSender\HttpAdapter;
 class CurlHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterface
 {
     /**
+     * @var array
+     */
+    protected $lastRequest;
+
+    /**
      * {@inheritDoc}
      */
     public function getContent($url, $method = 'GET', array $headers = array(), $data = array())
@@ -48,6 +53,13 @@ class CurlHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
         // execute the request
         $content = curl_exec($c);
 
+        $this->setLastRequest([
+            'url' => $url,
+            'method' => $method,
+            'headers' => $headers,
+            'data' => $data,
+        ]);
+
         curl_close($c);
 
         if (false === $content) {
@@ -63,6 +75,26 @@ class CurlHttpAdapter extends AbstractHttpAdapter implements HttpAdapterInterfac
     public function getName()
     {
         return 'curl';
+    }
+
+    /**
+     * @param bool|false $string
+     *
+     * @return mixed|string
+     */
+    public function getLastRequest($string = false)
+    {
+        return ($string) ? json_encode($this->lastRequest) : $this->lastRequest;
+    }
+
+    /**
+     * Return last request as string or object
+     *
+     * @param array $lastRequest
+     */
+    protected function setLastRequest($lastRequest)
+    {
+        $this->lastRequest = $lastRequest;
     }
 }
 

--- a/src/HttpAdapter/HttpAdapterInterface.php
+++ b/src/HttpAdapter/HttpAdapterInterface.php
@@ -41,6 +41,15 @@ interface HttpAdapterInterface
      * @return string
      */
     public function getName();
+
+    /**
+     * Return last request as string or object
+     *
+     * @param bool|false $string
+     *
+     * @return mixed|string
+     */
+    public function getLastRequest($string = false);
 }
 
 // vim: set softtabstop=4 tabstop=4 shiftwidth=4 autoindent:


### PR DESCRIPTION
```php
$sender = new \SmsSender\SmsSender();
try {
    $sendResult = $sender->send('0642424242', 'It\'s the answer.', 'Kévin');
} catch(\SmsSender\Exception\WrappedException $e){
    if($e->getWrappedException() && $e->getWrappedException() instanceof \SmsSender\Exception\AdapterException){
        $smsException = new \Exception($e->getWrappedException()->getMessage(), $e->getWrappedException()->getCode(), $e);
        if($e->getWrappedException()->getData()){
            var_dump($e->getWrappedException()->getData()); // request data
        }

    }
    throw $smsException;
}
```