### PR TITLE
#4 add an exception to parse response

### DIFF
--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SmsSender\Exception;
+
+class ResponseException extends \RuntimeException
+{
+    /**
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array $data
+     */
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+}


### PR DESCRIPTION
```php
if(!empty($responseData['Code'])){
    $smsData['status'] = ResultInterface::STATUS_FAILED;
    $smsData['message'] = !empty($responseData['Desc']) ? $responseData['Desc'] : 'Result status code: '.$responseData['Code'];
    $responseException = new ResponseException($smsData['message'], $responseData['Code']);
    $responseException->getData($responseData);
    throw $responseException;
}
```